### PR TITLE
Fixed error of CSpect executing

### DIFF
--- a/Py-Hdfm-Gooey/py-hdfm-gooey.py
+++ b/Py-Hdfm-Gooey/py-hdfm-gooey.py
@@ -263,7 +263,7 @@ class MainWindow(QMainWindow):
 
             try:
                 index = next(i for i, v in enumerate(tuple_type) if v == text_value)
-                return tuple_type[index]
+                return tuple_type[index][1]
             except StopIteration:
                 return None  # value not found
         


### PR DESCRIPTION
Hi, running CSpect does not work due to bad tuple indexing. There is a fix. Vitek